### PR TITLE
Fix for Unity 2018.1 (#54)

### DIFF
--- a/Editor/Library/W.meta
+++ b/Editor/Library/W.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: fb25cbfe030fd9244a54cd98bc33e7ce
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/GSDRootUtil.cs
+++ b/GSDRootUtil.cs
@@ -73,7 +73,7 @@ namespace GSD{
 			if(tObj != null){
 				tString = UnityEditor.AssetDatabase.GetAssetPath( tObj );
 				if(tString == null || tString.Length < 1){
-#if UNITY_2018_1_OR_NEWER
+#if UNITY_2018_2_OR_NEWER
                     Object parentObject = UnityEditor.PrefabUtility.GetCorrespondingObjectFromSource(tObj); 
 #else
                     Object parentObject = UnityEditor.PrefabUtility.GetPrefabParent(tObj);


### PR DESCRIPTION
* Merged in changes from MicroGSD/master

* - Added support for Unity 2018.1+
- Modified unit tests to display execution time and improved test performance (removed multiple GameObject.Find calls)
- Added Clean up tests to RoadArchitect->Testing menu

* Remove meta files for missing/unused assets

* Add missing .meta files

* Fix for wrong Unity version symbol in GSDRoadUtil.cs causing exception in Unity 2018.1.x
Remove meta file for directory that doesn't exist on import